### PR TITLE
Optional manual implementation as a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,8 @@ repository = "https://github.com/JoshMcguigan/multi_try"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = []
+manual = []
+
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi_try"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Josh Mcguigan"]
 edition = "2018"
 description = "Safely combine results"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,35 @@
 //! See the documentation for the [`MultiTry` trait] for more information and an example.
 //!
 //! [`MultiTry` trait]: trait.MultiTry.html
+//!
+//! # Manual implementation
+//!
+//! To manually implement the [`MultiTry` trait], you need to enable the `manual` feature
+//! and then use the [`impl_multi_try`] macro somewhere, with the amount of results you need to compare.
+//!
+//! ```no_run
+//! use multi_try::impl_multi_try;
+//!
+//! // Impl multi_try for up to four elements
+//! impl_multi_try!(A, B, C, D);
+//!
+//! // Or for up to 25 elements
+//! impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, X, Y, Z);
+//!
+//! // Or just two
+//! impl_multi_try!(A, B);
+//! 
+//! // Or really just any number of elements you need and with any names you want.
+//! impl_multi_try!(THIS, IS, OK);
+//! ```
 
+/// Implements [`MultiTry`] for the given number of arguments.
+///
+/// This macro should only be used once.
 #[macro_export]
-macro_rules! impl_multi {
+macro_rules! impl_multi_try {
     ($($typ:ident),+) => {
-        /// Exposes the `and_try` method for combining multiple `Result` types.
+        /// Exposes the `and_try` method for combining multiple [`Result`] types.
         ///
         /// This is an extension trait designed to add functionality to the `Result` type. That
         /// means that to use this trait's methods, you must have it in scope:
@@ -106,7 +130,9 @@ macro_rules! impl_multi {
     };
 }
 
-/// Allows you to create multiple implementations recursively, instead of manually.
+/// Should not be used manually
+/// 
+/// Implements [`MultiTry`] recursively for the number of arguments passed.
 #[macro_export]
 macro_rules! impl_multi_try_recursive {
     ($first:ident) => {
@@ -119,6 +145,9 @@ macro_rules! impl_multi_try_recursive {
     };
 }
 
+/// Should not be used manually
+/// 
+/// Implements [`MultiTry`] for a specific number of values.
 #[macro_export]
 macro_rules! impl_multi_try_for {
     ($($typ:ident),+) => {
@@ -142,4 +171,4 @@ macro_rules! impl_multi_try_for {
 }
 
 #[cfg(not(feature = "manual"))]
-impl_multi!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,29 +120,16 @@ macro_rules! impl_multi_try {
     };
 }
 
-impl_multi_try!(A);
-impl_multi_try!(A, B);
-impl_multi_try!(A, B, C);
-impl_multi_try!(A, B, C, D);
-impl_multi_try!(A, B, C, D, E);
-impl_multi_try!(A, B, C, D, E, F);
-impl_multi_try!(A, B, C, D, E, F, G);
-impl_multi_try!(A, B, C, D, E, F, G, H);
-impl_multi_try!(A, B, C, D, E, F, G, H, I);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
-impl_multi_try!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+/// Allows you to create multiple implementations recursively, instead of manually.
+macro_rules! impl_multi_try_multiple {
+    ($first:ident) => {
+        impl_multi_try!($first);
+    };
+
+    ($first:ident, $($rest:ident),+) => {
+        impl_multi_try!($first, $($rest),+);
+        impl_multi_try_multiple!($($rest),+);
+    };
+}
+
+impl_multi_try_multiple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,95 +11,116 @@
 //!
 //! [`MultiTry` trait]: trait.MultiTry.html
 
-/// Exposes the `and_try` method for combining multiple `Result` types.
-///
-/// This is an extension trait designed to add functionality to the `Result` type. That
-/// means that to use this trait's methods, you must have it in scope:
-///
-/// ```no_run
-/// use multi_try::MultiTry;
-/// ```
-///
-/// The `Ok` variant of each combined `Result` can have any type. Each value will be combined into
-/// a tuple. We support up to 27 items, though we never expect anyone to need anything close to
-/// that. The `Err` variant of each `Result` must have the same type. Each error that occurs will
-/// be combined into a single `Vec`.
-///
-/// The idea is that you can try many different operations, collect any errors that occurred, and
-/// then only proceed if every operation was a success. The example below demonstrates that:
-///
-/// ```no_run
-/// use multi_try::MultiTry;
-///
-/// struct A {
-///     b: Result<i32, MyErr>,
-///     c: Result<i64, MyErr>,
-///     d: Result<f32, MyErr>,
-/// }
-///
-/// struct ValidatedA {
-///     b: i32,
-///     c: i64,
-///     d: f32,
-/// }
-///
-/// enum MyErr {
-///     FailedB,
-///     FailedC,
-///     FailedD,
-/// }
-///
-/// fn validate(a: A) -> Result<ValidatedA, Vec<MyErr>> {
-///     // Only continue beyond this point if all the `Result` values were `Ok`
-///     let (b, c, d) = a.b.and_try(a.c).and_try(a.d)?;
-///
-///     Ok(ValidatedA { b, c, d })
-/// }
-/// ```
-pub trait MultiTry<RT, ERR> {
-    /// The output of the `and_try` operation
-    type Output;
+#[macro_export]
+macro_rules! impl_multi {
+    ($($typ:ident),+) => {
+        /// Exposes the `and_try` method for combining multiple `Result` types.
+        ///
+        /// This is an extension trait designed to add functionality to the `Result` type. That
+        /// means that to use this trait's methods, you must have it in scope:
+        ///
+        /// ```no_run
+        /// use multi_try::MultiTry;
+        /// ```
+        ///
+        /// The `Ok` variant of each combined `Result` can have any type. Each value will be combined into
+        /// a tuple. We support up to 27 items, though we never expect anyone to need anything close to
+        /// that. The `Err` variant of each `Result` must have the same type. Each error that occurs will
+        /// be combined into a single `Vec`.
+        ///
+        /// The idea is that you can try many different operations, collect any errors that occurred, and
+        /// then only proceed if every operation was a success. The example below demonstrates that:
+        ///
+        /// ```no_run
+        /// use multi_try::MultiTry;
+        ///
+        /// struct A {
+        ///     b: Result<i32, MyErr>,
+        ///     c: Result<i64, MyErr>,
+        ///     d: Result<f32, MyErr>,
+        /// }
+        ///
+        /// struct ValidatedA {
+        ///     b: i32,
+        ///     c: i64,
+        ///     d: f32,
+        /// }
+        ///
+        /// enum MyErr {
+        ///     FailedB,
+        ///     FailedC,
+        ///     FailedD,
+        /// }
+        ///
+        /// fn validate(a: A) -> Result<ValidatedA, Vec<MyErr>> {
+        ///     // Only continue beyond this point if all the `Result` values were `Ok`
+        ///     let (b, c, d) = a.b.and_try(a.c).and_try(a.d)?;
+        ///
+        ///     Ok(ValidatedA { b, c, d })
+        /// }
+        /// ```
+        pub trait MultiTry<RT, ERR> {
+            /// The output of the `and_try` operation
+            type Output;
 
-    /// Returns the current `Result` combined with the given `Result`. If both are `Ok`, this will
-    /// return a new tuple that combines the results. If either have failed, this will return a
-    /// vector containing each error that occurred.
-    ///
-    /// ```
-    /// use multi_try::MultiTry;
-    /// # // These functions are used to get around type inference issues
-    /// # fn Ok<T>(value: T) -> Result<T, &'static str> { Result::Ok(value) }
-    /// # fn Err<E>(err: E) -> Result<i32, E> { Result::Err(err) }
-    ///
-    /// # fn main() -> Result<(), Vec<&'static str>> {
-    /// // Combines two results so we get a 2-tuple
-    /// assert_eq!(Ok(1).and_try(Ok("abc"))?, (1, "abc"));
-    /// // Combines two results with another result so we get a 3-tuple
-    /// assert_eq!(Ok(1).and_try(Ok("abc")).and_try(Ok(37.4))?, (1, "abc", 37.4));
-    /// // Even if one succeeds, we only return Ok() if they both do
-    /// assert_eq!(Err("bad!").and_try(Ok(32)).unwrap_err(), vec!["bad!"]);
-    /// assert_eq!(Ok(1).and_try(Err("very bad!")).unwrap_err(), vec!["very bad!"]);
-    /// // If both fail, we return both errors
-    /// assert_eq!(Err("bad!").and_try(Err("very bad!")).unwrap_err(), vec!["bad!", "very bad!"]);
-    /// # Result::Ok(()) }
-    /// ```
-    fn and_try(self, other: Result<RT, ERR>) -> Self::Output;
-}
-
-// Allows you to combine Result<T, ERR> with Result<RT, ERR> to get Result<(T, RT), Vec<ERR>>
-impl<T, RT, ERR> MultiTry<RT, ERR> for Result<T, ERR> {
-    type Output = Result<(T, RT), Vec<ERR>>;
-
-    fn and_try(self, other: Result<RT, ERR>) -> Self::Output {
-        match (self, other) {
-            (Ok(a), Ok(b)) => Ok((a, b)),
-            (Ok(_), Err(eb)) => Err(vec![eb]),
-            (Err(ea), Ok(_)) => Err(vec![ea]),
-            (Err(ea), Err(eb)) => Err(vec![ea, eb]),
+            /// Returns the current `Result` combined with the given `Result`. If both are `Ok`, this will
+            /// return a new tuple that combines the results. If either have failed, this will return a
+            /// vector containing each error that occurred.
+            ///
+            /// ```
+            /// use multi_try::MultiTry;
+            /// # // These functions are used to get around type inference issues
+            /// # fn Ok<T>(value: T) -> Result<T, &'static str> { Result::Ok(value) }
+            /// # fn Err<E>(err: E) -> Result<i32, E> { Result::Err(err) }
+            ///
+            /// # fn main() -> Result<(), Vec<&'static str>> {
+            /// // Combines two results so we get a 2-tuple
+            /// assert_eq!(Ok(1).and_try(Ok("abc"))?, (1, "abc"));
+            /// // Combines two results with another result so we get a 3-tuple
+            /// assert_eq!(Ok(1).and_try(Ok("abc")).and_try(Ok(37.4))?, (1, "abc", 37.4));
+            /// // Even if one succeeds, we only return Ok() if they both do
+            /// assert_eq!(Err("bad!").and_try(Ok(32)).unwrap_err(), vec!["bad!"]);
+            /// assert_eq!(Ok(1).and_try(Err("very bad!")).unwrap_err(), vec!["very bad!"]);
+            /// // If both fail, we return both errors
+            /// assert_eq!(Err("bad!").and_try(Err("very bad!")).unwrap_err(), vec!["bad!", "very bad!"]);
+            /// # Result::Ok(()) }
+            /// ```
+            fn and_try(self, other: Result<RT, ERR>) -> Self::Output;
         }
-    }
+
+        // Allows you to combine Result<T, ERR> with Result<RT, ERR> to get Result<(T, RT), Vec<ERR>>
+        impl<T, RT, ERR> MultiTry<RT, ERR> for Result<T, ERR> {
+            type Output = Result<(T, RT), Vec<ERR>>;
+
+            fn and_try(self, other: Result<RT, ERR>) -> Self::Output {
+                match (self, other) {
+                    (Ok(a), Ok(b)) => Ok((a, b)),
+                    (Ok(_), Err(eb)) => Err(vec![eb]),
+                    (Err(ea), Ok(_)) => Err(vec![ea]),
+                    (Err(ea), Err(eb)) => Err(vec![ea, eb]),
+                }
+            }
+        }
+
+        $crate::impl_multi_try_recursive!($($typ),+);
+    };
 }
 
-macro_rules! impl_multi_try {
+/// Allows you to create multiple implementations recursively, instead of manually.
+#[macro_export]
+macro_rules! impl_multi_try_recursive {
+    ($first:ident) => {
+        $crate::impl_multi_try_for!($first);
+    };
+
+    ($first:ident, $($rest:ident),+) => {
+        $crate::impl_multi_try_for!($first, $($rest),+);
+        $crate::impl_multi_try_recursive!($($rest),+);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_multi_try_for {
     ($($typ:ident),+) => {
         impl<RT, ERR, $($typ),+> MultiTry<RT, ERR> for Result<($($typ),+,), Vec<ERR>> {
             type Output = Result<($($typ),*, RT), Vec<ERR>>;
@@ -120,16 +141,5 @@ macro_rules! impl_multi_try {
     };
 }
 
-/// Allows you to create multiple implementations recursively, instead of manually.
-macro_rules! impl_multi_try_multiple {
-    ($first:ident) => {
-        impl_multi_try!($first);
-    };
-
-    ($first:ident, $($rest:ident),+) => {
-        impl_multi_try!($first, $($rest),+);
-        impl_multi_try_multiple!($($rest),+);
-    };
-}
-
-impl_multi_try_multiple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+#[cfg(not(feature = "manual"))]
+impl_multi!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! To manually implement the [`MultiTry` trait], you need to enable the `manual` feature
 //! and then use the [`impl_multi_try`] macro somewhere, with the amount of results you need to compare.
 //!
-//! ```no_run
+//! ```ignore
 //! use multi_try::impl_multi_try;
 //!
 //! // Impl multi_try for up to four elements


### PR DESCRIPTION
Hello!

I really, really like this library, so I made a few tweaks that I needed for a project, even though this project is pretty old by now.

I made a couple of changes:
- A recursive macro that implements all needed for us, with one call instead of the 25 we made earlier.
- Wrapped the MultiTry trait itself in a macro, to allow for manually implementing any number of items you need, behind a feature flag to not break api.

When enabling the `manual` feature, a simple call to the macro is removed from the library. It then needs to be called, as explained in "Manual implementation" in the docs. Since it's a feature-flag, no tests are broken, except for the doc-tests. I decided to ignore this doc-test instead, because it's simple. If anyone has an idea to make it compile, you're very welcome!

I also added a bit of documentation to the other macros that got exported, to warn users, because of limits with rusts macros, when being exported to other crates.

Hope this PR isn't for no use! Have a nice day😊